### PR TITLE
Fixed incorrect Twilio package version causing .parameter() not working

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dotenv": "^4.0.0",
     "express": "^4.15.2",
     "body-parser": "^1.18.2",
-    "twilio": "^4.6.0"
+    "twilio": "^3.71.1"
   },
   "devDependencies": {
     "jest": "^19.0.2",


### PR DESCRIPTION
The last update set Twilio package version to 4.6.0 which doesn't exist resulting in some examples not working, namely `.parameter()` for clients.

This PR sets the correct package version to the latest published: 3.71.1

**See example: **
https://www.twilio.com/docs/voice/how-share-information-between-your-applications?code-sample=code-generate-client-parameter-twiml-using-helper-libraries&code-language=Node.js&code-sdk-version=3.x